### PR TITLE
added a qbp update bashrc and changed qcar2 bashrc to be more robust

### DIFF
--- a/1_setup/updatebashrc_qbp.sh
+++ b/1_setup/updatebashrc_qbp.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Line to add to .bashrc
+line="export PYTHONPATH=/home/nvidia/Documents/Quanser/0_libraries/python"
+
+# Check if the line is already in the file to avoid duplicates
+if ! grep -q "export PYTHONPATH=/home/nvidia/Documents/Quanser/0_libraries/python" ~/.bashrc
+then
+    # If the line is not in the file, append it
+    echo "$line" >> ~/.bashrc
+    echo "PYTHONPATH added to ~/.bashrc"
+    
+    # Source the .bashrc to apply changes immediately
+    source ~/.bashrc
+else
+    echo "PYTHONPATH already exists in ~/.bashrc"
+fi
+
+
+# place any packages that need to be updated here
+# check for an internet connection before attempting to install packages
+if nc -zw1 google.com 443; then
+    echo "internet connection identified"
+else
+    echo "no internet connection found"
+    echo "no packages were attempted to be installed"
+fi

--- a/1_setup/updatebashrc_qcar2.sh
+++ b/1_setup/updatebashrc_qcar2.sh
@@ -4,8 +4,20 @@
 line1="export PYTHONPATH=$PYTHONPATH:/home/nvidia/Documents/Quanser/0_libraries/python"
 line2="export QAL_DIR=/home/nvidia/Documents/Quanser"
 
-# Add a newline first (in case file doesn't end with one), then append
-printf "\n%s\n%s\n" "$line1" "$line2" >> ~/.bashrc
+# update the bashrc if PYTHONPATH and QAL_DIR are not already present
+if ! grep -q "export PYTHONPATH=:/home/nvidia/Documents/Quanser/0_libraries/python" ~/.bashrc; then
+    echo "$line1" >> ~/.bashrc
+    echo "PYTHONPATH added to ~/.bashrc"
+else
+    echo "PYTHONPATH already exists in ~/.bashrc"
+fi
+
+if ! grep -q "export QAL_DIR=/home/nvidia/Documents/Quanser" ~/.bashrc; then
+    echo "$line2" >> ~/.bashrc
+    echo "QAL_DIR added to ~/.bashrc"
+else
+    echo "QAL_DIR already exists in ~/.bashrc"
+fi
 
 # TODO: remove when the bug fix is released
 # Patch quanserSDK scan match
@@ -15,11 +27,17 @@ sudo sed -i '109s/def open(resolution, max_range):/def open(self, resolution, ma
 # Patch line 248: fix "pose"
 sudo sed -i '248s/                                                                     ffi.from_buffer(_SINGLE_ARRAY3, pose) if pos is not None else ffi.NULL, ffi.from_buffer(_SINGLE_ARRAY, score) if score is not None else ffi.NULL, ffi.from_buffer(_SINGLE_ARRAY9, covariance) if covariance is not None else ffi.NULL)/                                                                     ffi.from_buffer(_SINGLE_ARRAY3, pose) if pose is not None else ffi.NULL, ffi.from_buffer(_SINGLE_ARRAY, score) if score is not None else ffi.NULL, ffi.from_buffer(_SINGLE_ARRAY9, covariance) if covariance is not None else ffi.NULL)/' "$FILE"
 
-# Installing dependencies
-sudo apt install python3-setuptools -y
-pip3 install transforms3d
-sudo apt-get install ros-humble-tf-transformations -y
-python3 -m pip install numpy==1.23 --upgrade
-echo "Lines added to .bashrc and changes applied."
+# Installing dependencies if there is an internet connection
+if nc -zw1 google.com 443; then
+    sudo apt install python3-setuptools -y
+    pip3 install transforms3d
+    sudo apt-get install ros-humble-tf-transformations -y
+    python3 -m pip install numpy==1.23 --upgrade
+    echo "Lines added to .bashrc and changes applied."
+else
+    echo "no internet connection found"
+    echo "no packages were attempted to be installed"
+fi
+
 # Source the .bashrc to apply changes immediately
 source ~/.bashrc


### PR DESCRIPTION
I have changed the qcar2_updatebashrc.sh file to check for the necessary environment variables first before trying to update the bashrc. It will also check for an internet connection before attempting to install/update certain packages.

I have also added a qbp_updatebashrc.sh file to update the bashrc for the qbp with the correct environment variable that is aligned to the curriculum. It also has the structures used in the qcar2_updatebashrc.sh.

Both have been tested on the qcar2 and qbp.